### PR TITLE
Upgrade demo to Flink 1.12.1.

### DIFF
--- a/client-image/Dockerfile
+++ b/client-image/Dockerfile
@@ -16,17 +16,17 @@
 # limitations under the License.
 ###############################################################################
 
-FROM flink:1.11.1-scala_2.11
+FROM flink:1.12.1-scala_2.11
 
 # Copy sql-client script
 COPY sql-client/ /opt/sql-client
 RUN mkdir -p /opt/sql-client/lib
 
 # Download connector libraries
-RUN wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.11.1/flink-json-1.11.1.jar; \
-    wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka_2.11/1.11.1/flink-sql-connector-kafka_2.11-1.11.1.jar; \
-    wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7_2.11/1.11.1/flink-sql-connector-elasticsearch7_2.11-1.11.1.jar; \
-    wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-jdbc_2.11/1.11.1/flink-connector-jdbc_2.11-1.11.1.jar; \
+RUN wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/1.12.1/flink-json-1.12.1.jar; \
+    wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka_2.11/1.12.1/flink-sql-connector-kafka_2.11-1.12.1.jar; \
+    wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7_2.11/1.12.1/flink-sql-connector-elasticsearch7_2.11-1.12.1.jar; \
+    wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-jdbc_2.11/1.12.1/flink-connector-jdbc_2.11-1.12.1.jar; \
     wget -P /opt/sql-client/lib/ https://repo.maven.apache.org/maven2/org/postgresql/postgresql/42.2.14/postgresql-42.2.14.jar;
 
 # Copy configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,14 +50,14 @@ services:
       KAFKA_BOOTSTRAP: kafka
       ES_HOST: elasticsearch
   jobmanager:
-    image: flink:1.11.1-scala_2.11
+    image: flink:1.12.1-scala_2.11
     ports:
       - "8081:8081"
     command: jobmanager
     environment:
       - JOB_MANAGER_RPC_ADDRESS=jobmanager
   taskmanager:
-    image: flink:1.11.1-scala_2.11
+    image: flink:1.12.1-scala_2.11
     depends_on:
       - jobmanager
     command: taskmanager

--- a/postgres-image/postgres_bootstrap.sql
+++ b/postgres-image/postgres_bootstrap.sql
@@ -10,8 +10,9 @@ create table members (
 	address_country VARCHAR(10),
 	insurance_company VARCHAR(25),
 	insurance_number VARCHAR(50),
-	ts_created TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-	ts_updated TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+	--Avoiding temporal data types purely for the sake of convenience, given the existing limitations.
+	ts_created VARCHAR(20) DEFAULT TO_CHAR(CURRENT_TIMESTAMP,'YYYY-MM-DD HH:MI:SS'),
+	ts_updated VARCHAR(20) DEFAULT TO_CHAR(CURRENT_TIMESTAMP,'YYYY-MM-DD HH:MI:SS'),
 	PRIMARY KEY(id)
 );
 

--- a/register-postgres.json
+++ b/register-postgres.json
@@ -12,7 +12,6 @@
         "table.whitelist": "claims.accident_claims",
         "value.converter": "org.apache.kafka.connect.json.JsonConverter",
         "value.converter.schemas.enable": false,
-        "decimal.handling.mode": "double",
-        "tombstones.on.delete":false
+        "decimal.handling.mode": "double"
     }
 }

--- a/register-postgres.json
+++ b/register-postgres.json
@@ -9,7 +9,7 @@
         "database.password": "postgres",
         "database.dbname" : "postgres",
         "database.server.name": "pg_claims",
-        "schema.whitelist": "claims",
+        "table.whitelist": "claims.accident_claims",
         "value.converter": "org.apache.kafka.connect.json.JsonConverter",
         "value.converter.schemas.enable": false,
         "decimal.handling.mode": "double",


### PR DESCRIPTION
- [x] Bumped the Flink images to 1.12.1 and removed some unnecessary configuration (see "Discussions/Known Bugs/Flink 1.11");
- [x] Updated the README and simplified some queries (e.g. cross-catalog references).

**TODO:**
- [ ] Auto-load the Kibana dashboard;
- [ ] Add alternative setup not depending on Kafka (i.e. using [these](https://github.com/ververica/flink-cdc-connectors) CDC connectors).